### PR TITLE
feat: migrate to combinator based settings for blueprint parameterization

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -5,14 +5,7 @@ Network = require("scripts/network")
 GUI = require("scripts/gui")
 UndoTracker = require("scripts/undo_tracker")
 
--- Event filter for entity events
-EVENT_TYPE_FILTER = {
-  {filter = "type", type = "linked-belt"},
-  {filter = "type", type = "entity-ghost"},
-}
-
--- Left click event name
-LEFT_CLICK_EVENT = 'ut-left-click'
+require("scripts/constants")
 
 script.on_init(Network.init)
 script.on_event(defines.events.on_tick, function ()
@@ -21,25 +14,53 @@ script.on_event(defines.events.on_tick, function ()
   UndoTracker.tick()
 end)
 
-local UPGRADE_PORT_DATA = nil
+-- Track entities marked for upgrade
+if not storage.markedForUpgrade then 
+  storage.markedForUpgrade = {} 
+end
+
+function markForUpgrade(entity)
+  if not storage.markedForUpgrade then storage.markedForUpgrade = {} end
+  storage.markedForUpgrade[entity.position.x .. "," .. entity.position.y] = entity
+end
+
+function getUpgradeEntity(position)
+  if not storage.markedForUpgrade then storage.markedForUpgrade = {} end
+  return storage.markedForUpgrade[position.x .. "," .. position.y]
+end
+
+function popUpgradeEntity(position)
+  local key = position.x .. "," .. position.y
+  local entity = storage.markedForUpgrade[key]
+  if entity then
+    storage.markedForUpgrade[key] = nil
+  end
+  return entity
+end
 
 ---Handles creation of a port
 ---@param event EventData.on_built_entity|EventData.on_robot_built_entity|EventData.on_entity_cloned|EventData.script_raised_built|EventData.script_raised_revive
 function handleEntityCreated(event)
-  local upgradeEntity = UPGRADE_PORT_DATA
-  UPGRADE_PORT_DATA = nil
-  if upgradeEntity and not upgradeEntity.name then
-    -- Not an in-place upgrade
-    upgradeEntity = nil
+  if Util.isGhost(event.entity) then
+    local settings = Network.tryGetCombinatorSettings(event.entity)
+    if settings then
+      local entities = event.entity.surface.find_entities_filtered({position=event.entity.position, radius=0, type="entity-ghost"})
+      for _, entity in pairs(entities) do
+        if Util.isPort(entity) then
+          entity.tags = settings
+        end
+      end
+    end
   end
 
+  local upgradeEntity = popUpgradeEntity(event.entity.position)
   local entity = event.entity or event.destination
   if not Util.isPort(entity) then return end
   Network.addPort(entity, upgradeEntity)
 
-  local settings = event.tags or (event.stack and event.stack.tags)-- or priorSettings
-  if settings then
-    Network.importSettings(entity, settings)
+  local settings = (upgradeEntity and upgradeEntity.settings) or event.tags or (event.stack and event.stack.tags)
+  if settings and next(settings) ~= nil then
+    Network.configurePort(entity, settings[MOD_DATA_LEFT_LANE], settings[MOD_DATA_RIGHT_LANE])
   end
 end
 script.on_event(defines.events.on_entity_cloned, handleEntityCreated, EVENT_TYPE_FILTER)
@@ -49,46 +70,48 @@ script.on_event(defines.events.script_raised_built, handleEntityCreated, EVENT_T
 script.on_event(defines.events.script_raised_revive, handleEntityCreated, EVENT_TYPE_FILTER)
 script.on_event(defines.events.on_space_platform_built_entity, handleEntityCreated, EVENT_TYPE_FILTER)
 
-
-
--- Record settings from an existing port at the new build locaation so we can transfer them to the new port
+-- Record settings from an existing port at the new build location
 function handlePreBuildEntity(event)
-  UPGRADE_PORT_DATA = { position=event.position }
+  markForUpgrade({position=event.position})
 end
 script.on_event(defines.events.on_pre_build, handlePreBuildEntity)
 
+--Handle preparing for upgrade
+function handlePreUpgradeEntity(event)
+  local entity = event.entity
+  markForUpgrade({
+    position=entity.position, 
+    name=entity.name, 
+    type=entity.type, 
+    unit_number=entity.unit_number, 
+    surface=entity.surface
+  })
+end
+script.on_event(defines.events.on_marked_for_upgrade, handlePreUpgradeEntity, EVENT_TYPE_FILTER)
 
+--Handle upgrade cancelled
+function handleUpgradeCancelled(event)
+  popUpgradeEntity(event.entity.position)
+end
+script.on_event(defines.events.on_cancelled_upgrade, handleUpgradeCancelled, EVENT_TYPE_FILTER)
 
 ---Handle the removal of a port
----@param event EventData.on_entity_died|EventData.on_robot_mined_entity|EventData.on_player_mined_entity|EventData.script_raised_destroy
+---@param event EventData.on_entity_died|EventData.on_robot_mined_entity|EventData.on_player_mined_entity|EventData.script_rad_destroy
 function handleEntityRemoved(event)
   local entity = event.entity
   if not Util.isPort(entity) then return end
 
-  -- This copies this port's settings to the created item, not sure that's helpful though...
-  -- local settings = Network.exportSettings(entity)
-  -- for idx = 1, #event.buffer do
-  --   local item = event.buffer[idx]
-  --   if item.name == entity.name then
-  --     for tag, value in pairs(settings) do
-  --       item.set_tag(tag, value)
-  --     end
-  --   end
-  -- end
-  if UPGRADE_PORT_DATA and Util.positionsEqual(UPGRADE_PORT_DATA.position, entity.position) then
-    -- Upgrade this port in-place, so save some data_ModSetting for use in handleEntityCreated
-    UPGRADE_PORT_DATA.name = entity.name
-    UPGRADE_PORT_DATA.type = entity.type
-    UPGRADE_PORT_DATA.unit_number = entity.unit_number
-    UPGRADE_PORT_DATA.surface = entity.surface
-    UPGRADE_PORT_DATA.tags = entity.tags
+  local upgradeEntity = getUpgradeEntity(entity.position)
+  if upgradeEntity then
+    -- Upgrade this port in-place, save settings for use in handleEntityCreated
+    local port = Network.getPort(entity)
+    upgradeEntity.name = entity.name
+    upgradeEntity.type = entity.type
+    upgradeEntity.unit_number = entity.unit_number
+    upgradeEntity.surface = entity.surface
+    upgradeEntity.settings = entity.tags or Network.getSettings(port) or port.tags
+    markForUpgrade(upgradeEntity) -- Update the stored entity
   else
-    -- Remove the port entirely
-    local tags = Network.exportSettings(entity)
-    if next(tags, nil) then
-      -- If the port has any settings, save them for the undo record next tick
-      UndoTracker.recordPortRemoved(entity, tags)
-    end
     Network.removePort(entity, event.buffer)
   end
   AnimationTracker.teardown(entity)
@@ -100,30 +123,19 @@ script.on_event(defines.events.on_player_mined_entity, handleEntityRemoved, EVEN
 script.on_event(defines.events.script_raised_destroy, handleEntityRemoved, EVENT_TYPE_FILTER)
 script.on_event(defines.events.on_space_platform_mined_entity, handleEntityRemoved, EVENT_TYPE_FILTER)
 
+-- Handle settings paste
+function handleSettingsPaste(event)
+  if not Util.isOutput(event.source) then return end
+  local sourcePort = Network.getPort(event.source)
+  if not sourcePort then return end
+  local settings = Network.getSettings(sourcePort)
+  if not settings then return end
 
-
--- Copy output configuration to the blueprint entities
-function handleBlueprintSetup(event)
-  if not event.stack or not event.stack.is_blueprint_setup() then return end
-
-  local blueprintEntities = event.stack.get_blueprint_entities()
-  if not blueprintEntities then return end
-
-  local mapping = event.mapping.get()
-  for _, bpEntity in pairs(blueprintEntities) do
-    if not Util.isPort(bpEntity) then goto continue end
-
-    local worldEntity = mapping[bpEntity.entity_number]
-    if not worldEntity then goto continue end
-
-    local settings = Network.exportSettings(worldEntity)
-    event.stack.set_blueprint_entity_tags(bpEntity.entity_number, settings)
-    ::continue::
-  end
+  local entity = event.destination
+  if not Util.isOutput(entity) then return end
+  Network.importSettings(entity, settings)
 end
-script.on_event(defines.events.on_player_setup_blueprint, handleBlueprintSetup)
-
-
+script.on_event(defines.events.on_entity_settings_pasted, handleSettingsPaste)
 
 -- Open output port GUI
 function handleLeftClick(event)
@@ -139,43 +151,6 @@ function handleLeftClick(event)
   GUI.openOutputPortGui(player, entity)
 end
 script.on_event(LEFT_CLICK_EVENT, handleLeftClick)
-
-
-
--- function handleGuiOpened(event)
---   if event.gui_type ~= defines.gui_type.entity then return end
-  
---   local entity = event.entity
---   if not Util.isPort(entity) then return end
-
---   log("Opened: "..entity.name)
--- end
--- script.on_event(defines.events.on_gui_opened, handleGuiOpened)
-
-
--- function handleEntitySelected(event)
---   local player = game.get_player(event.player_index)
---   local entity = player.selected
---   if not entity or not Util.isPort(entity) then return end
-
---   log("Opened: "..entity.name)
--- end
--- script.on_event(defines.events.on_selected_entity_changed , handleEntitySelected)
-
--- function handleCursorChanged(event)
---   local player = game.get_player(event.player_index)
---   local item = player.cursor_stack
---   if not item or not item.valid_for_read then return end
---   if not Util.isPort(item) then return end
-  
---   -- TODO: Show correct entity ghost for output ports
---   if Util.isOutput(item) then
---     -- player.cursor_stack.direc
---   end
---   -- log(serpent.line(item))
---   -- item.linked_belt_type = Util.isInput(item) and 'input' or 'output'
--- end
--- script.on_event(defines.events.on_player_cursor_stack_changed, handleCursorChanged)
 
 -- Handle rotation of port entities
 function handleEntityRotated(event)

--- a/control.lua
+++ b/control.lua
@@ -35,7 +35,7 @@ function popUpgradeEntity(position)
   if entity then
     storage.markedForUpgrade[key] = nil
   end
-  return entity
+  return entity and entity.name ~= nil and entity or nil
 end
 
 ---Handles creation of a port

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,3 +1,5 @@
+local defaultMask = require("__core__.lualib.collision-mask-defaults")
+
 Util = require("scripts/util")
 
 local TINT = {0.65, 0.65, 0.65} -- to recolor the items and entities
@@ -30,16 +32,21 @@ local BELT_TYPE_MAP = {
   ["turbo-underground-belt"] = "turbo"
 }
 
-function makePort(undergroundPrototype, direction)
+function getPortName(undergroundPrototype, direction)
+  return NAME_PREFIX..direction.."-"..undergroundPrototype.name
+end
+
+function makePort(undergroundPrototype, direction, allOutputNames)
   local entity = table.deepcopy(undergroundPrototype)
   entity.type = BASE_TYPE
-  entity.name = NAME_PREFIX..direction.."-"..undergroundPrototype.name
+  entity.name = getPortName(undergroundPrototype, direction)
   entity.minable.result = entity.name
   entity.fast_replaceable_group = BASE_TYPE
   if undergroundPrototype.next_upgrade then
     entity.next_upgrade = NAME_PREFIX..direction.."-"..undergroundPrototype.next_upgrade
   end
   entity.localised_name = {"entity-name."..entity.name}
+  entity.selection_priority = 100
   for key in pairs(entity.structure) do -- should maybe be a bit more general to deal with differently defined sprites
     entity.structure[key] = EMPTY_SPRITE4WAY
   end
@@ -127,6 +134,8 @@ function makePort(undergroundPrototype, direction)
     west = direction == 'output' and westSprite or eastSprite,
   }
 
+  entity.additional_pastable_entities = allOutputNames or {}
+
   local overlayEntity = {
     type = OVERLAY_TYPE,
     name = Util.getAnimEntityName(entity),
@@ -205,10 +214,39 @@ local leftClickEvent = {
 }
 data:extend{subgroup, leftClickEvent}
 
+local combinatorEntity = table.deepcopy(data.raw["constant-combinator"]["constant-combinator"])
+combinatorEntity.name = COMBINATOR_TYPE
+combinatorEntity.localised_name = {"entity-name."..combinatorEntity.name}
+combinatorEntity.selectable_in_game = false
+combinatorEntity.minable = nil
+combinatorEntity.hidden = true
+combinatorEntity.hidden_in_factoriopedia = true
+combinatorEntity.placeable_by = {
+  item = "constant-combinator",
+  count = 0
+}
+combinatorEntity.sprites = nil
+combinatorEntity.collision_mask = {
+  layers = {},
+  colliding_with_tiles_only = true,
+  consider_tile_transitions = false,
+  not_colliding_with_itself = true,
+}
+combinatorEntity.fast_replaceable_group = BASE_TYPE
+data:extend{combinatorEntity}
+
+local allOutputNames = {}
+
+for _, prototype in pairs(data.raw["underground-belt"]) do
+  if not IGNORED_PROTOTYPES[prototype.name] then
+    table.insert(allOutputNames, getPortName(prototype, 'output'))
+  end
+end
+
 for _, prototype in pairs(data.raw["underground-belt"]) do
   if not IGNORED_PROTOTYPES[prototype.name] then
     -- Make the input and output ports
     makePort(prototype, 'input')
-    makePort(prototype, 'output')
+    makePort(prototype, 'output', allOutputNames)
   end
 end

--- a/locale/en/underground-transport.cfg
+++ b/locale/en/underground-transport.cfg
@@ -9,6 +9,8 @@ ut-output-fast-underground-belt=Fast underground output
 ut-output-express-underground-belt=Express underground output
 ut-output-turbo-underground-belt=Turbo underground output
 
+underground-transport-output-combinator=Underground output combinator
+
 [ui]
 ut-output-header=Select items to output from the network
 ut-left-lane=Left lane:

--- a/migrations/002_add_combinators.lua
+++ b/migrations/002_add_combinators.lua
@@ -1,0 +1,47 @@
+
+-- Adds in combinators for previously-existing ports
+if not storage.networks then return end
+if storage.combinatorsAdded then return end
+
+-- Returns configuration settings for the given entity in a tags-compatible table
+function exportSettings(entity)
+  if Util.isGhost(entity) then
+    return entity.tags or {}
+  else
+    local port = Network.getPort(entity)
+    return createSettings(port.leftLane.item, port.rightLane.item)
+  end
+end
+
+for _, surface in pairs(game.surfaces) do
+  local network = Network.get(surface.name)
+  if not network then goto nextSurface end
+  log("migrating to combinators on "..surface.name)
+
+  for _, output in pairs(network.outputs) do
+    local settings = exportSettings(output.entity)
+    if settings then
+      log("creating combinator for "..output.entity.unit_number)
+      local port = Network.getPort(output.entity)
+      if not port then goto nextOutput end
+      if port.combinator then goto nextOutput end
+      local combinator = output.entity.surface.create_entity{
+        name = COMBINATOR_TYPE,
+        position = output.entity.position,
+        force = output.entity.force,
+        create_build_effect_smoke = false,
+        raise_built = false
+      }
+      port.combinator = combinator
+      local leftLane = settings[MOD_DATA_LEFT_LANE] and settings[MOD_DATA_LEFT_LANE].name or "nil"
+      local rightLane = settings[MOD_DATA_RIGHT_LANE] and settings[MOD_DATA_RIGHT_LANE].name or "nil"
+      log("left lane: "..leftLane)
+      log("right lane: "..rightLane)
+      Network.configurePort(output.entity, settings[MOD_DATA_LEFT_LANE], settings[MOD_DATA_RIGHT_LANE])
+    end
+    ::nextOutput::
+  end
+  ::nextSurface::
+end
+
+storage.combinatorsAdded = true

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -4,9 +4,11 @@ MOD_DATA_LEFT_LANE = MOD_DATA_KEY..'left'
 MOD_DATA_RIGHT_LANE = MOD_DATA_KEY..'right'
 BASE_TYPE = "linked-belt"
 OVERLAY_TYPE = "electric-energy-interface"
+COMBINATOR_TYPE = "underground-transport-output-combinator"
 OVERLAY_SUFFIX = "-overlay"
 EVENT_TYPE_FILTER = {
   {filter = "type", type = BASE_TYPE},
   {filter = "type", type = "entity-ghost"},
+  {filter = "type", type = COMBINATOR_TYPE},
 }
 LEFT_CLICK_EVENT = 'ut-left-click'

--- a/scripts/gui.lua
+++ b/scripts/gui.lua
@@ -25,6 +25,13 @@ function GUI.openOutputPortGui(player, entity)
     inventoryButtons = {},
     dirty = false, -- Set true if a change is made
   }
+  
+  -- Check if port is valid, if not close the window and return
+  if not data.port then
+    window.destroy()
+    return
+  end
+  
   if not storage.guiData then
     storage.guiData = {}
   end
@@ -68,14 +75,16 @@ function GUI.openOutputPortGui(player, entity)
   buttonContainer.style.horizontal_spacing = 10
   buttonContainer.style.column_alignments[1] = 'right'
 
+  local settings = Network.getSettings(data.port)
+
   buttonContainer.add{ type="label", caption={'ui.ut-left-lane'}, style="semibold_label" }
   data.chooseLeftButton = buttonContainer.add{ type="choose-elem-button", elem_type='item-with-quality' }
-  data.chooseLeftButton.elem_value = data.port.leftLane.item
+  data.chooseLeftButton.elem_value = settings[MOD_DATA_LEFT_LANE]
   data.bothButtonLeft = buttonContainer.add{ type="button", caption={'ui.ut-both-lanes'} }
 
   buttonContainer.add{ type="label", caption={'ui.ut-right-lane'}, style="semibold_label" }
   data.chooseRightButton = buttonContainer.add{ type="choose-elem-button", elem_type='item-with-quality' }
-  data.chooseRightButton.elem_value = data.port.rightLane.item
+  data.chooseRightButton.elem_value = settings[MOD_DATA_RIGHT_LANE]
   data.bothButtonRight = buttonContainer.add{ type="button", caption={'ui.ut-both-lanes'} }
 
   bodyFrame.add{ type="label", caption={'ui.ut-inventory-header'} }
@@ -113,6 +122,7 @@ function GUI.checkClose(entity)
 end
 
 function GUI.updateButtonStates(data)
+  if not data or not data.bothButtonLeft or not data.chooseLeftButton or not data.bothButtonRight or not data.chooseRightButton then return end
   data.bothButtonLeft.enabled = not not data.chooseLeftButton.elem_value
   data.bothButtonRight.enabled = not not data.chooseRightButton.elem_value
   data.dirty = true
@@ -123,12 +133,15 @@ function GUI.updateInventory()
   if not storage.guiData then return end
 
   for playerIndex, data in pairs(storage.guiData) do
-    if not data.outputPortWindow.valid or not data.entity.valid then
+    if not data or not data.outputPortWindow or not data.outputPortWindow.valid or not data.entity or not data.entity.valid then
       -- Cleanup bogus state if the window was closed externally
       GUI.closeOutputPortGui{player_index=playerIndex}
       return
     end
+    
+    if not data.port then return end
     local itemToCount = Network.getItemCounts(data.port)
+    if not itemToCount then return end
 
     -- Add new buttons as needed
     for itemKey, count in pairs(itemToCount) do
@@ -154,7 +167,7 @@ end
 function handleClick(event)
   if not storage.guiData then return end
   local data = storage.guiData[event.player_index]
-  if not data then return end
+  if not data or not data.port then return end
 
   if event.element == data.closeButton then
     GUI.closeOutputPortGui(event)
@@ -172,8 +185,10 @@ function handleClick(event)
     if not inventory then return end
     
     function insertFrom(lane)
+      if not lane or not lane.buffer then return end
       for i = #lane.buffer, 1, -1 do
         local entry = lane.buffer[i]
+        if not entry or not entry.inventory or not entry.inventory[1] then goto continue end
         local item = entry.inventory[1]
         local key = Util.itemFilterToKey(item)
         if key == itemKey then
@@ -181,6 +196,7 @@ function handleClick(event)
           inventory.insert(item)
           Network.removeItem(data.port, lane, i)
         end
+        ::continue::
       end
     end
     insertFrom(data.port.leftLane)

--- a/scripts/network.lua
+++ b/scripts/network.lua
@@ -120,29 +120,31 @@ function Network.tick()
           demands.lastIndex = 1
         end
         local outputEntry = demands[demands.lastIndex]
-        local manhattanDistance = Util.manhattanDistance(inputEntry.port.entity.position, outputEntry.port.entity.position)
+        if outputEntry and outputEntry.port then
+          local manhattanDistance = Util.manhattanDistance(inputEntry.port.entity.position, outputEntry.port.entity.position)
 
-        -- Advance to the next output
-        demands.lastIndex = demands.lastIndex + 1
+          -- Advance to the next output
+          demands.lastIndex = demands.lastIndex + 1
 
-        -- Don't proceed unless there's room in this output buffer
-        local output = Network.getPortLane(outputEntry.port, outputEntry.lane)
-        output.bufferLength = math.max(output.bufferLength, manhattanDistance * 4) -- 4 items/square 
+          -- Don't proceed unless there's room in this output buffer
+          local output = Network.getPortLane(outputEntry.port, outputEntry.lane)
+          output.bufferLength = math.max(output.bufferLength, manhattanDistance * 4) -- 4 items/square 
 
-        if #output.buffer < output.bufferLength then
-          if inputEntry.lane then
-            -- Insert from one of the input's lanes
-            local inputLane = inputEntry.port.entity.get_transport_line(inputEntry.lane)
-            Network.insertItem(outputEntry.port, output, inputLane[1], manhattanDistance)
-          else
-            -- Insert from an inserter ready to drop on the input
-            local inserter = inputEntry.inserter
-            Network.insertItem(outputEntry.port, output, inserter.held_stack, manhattanDistance)
+          if #output.buffer < output.bufferLength then
+            if inputEntry.lane then
+              -- Insert from one of the input's lanes
+              local inputLane = inputEntry.port.entity.get_transport_line(inputEntry.lane)
+              Network.insertItem(outputEntry.port, output, inputLane[1], manhattanDistance)
+            else
+              -- Insert from an inserter ready to drop on the input
+              local inserter = inputEntry.inserter
+              Network.insertItem(outputEntry.port, output, inserter.held_stack, manhattanDistance)
+            end
+
+            -- Advance to the next input
+            lastSupplyIdx, inputEntry = next(inputs, lastSupplyIdx)
+            if not lastSupplyIdx then break end -- No more available
           end
-
-          -- Advance to the next input
-          lastSupplyIdx, inputEntry = next(inputs, lastSupplyIdx)
-          if not lastSupplyIdx then break end -- No more available
         end
       end
     end
@@ -150,13 +152,15 @@ function Network.tick()
     -- Push items into outputs from their buffers
     for _, output in pairs(network.outputs) do
       for idx = 1, 2 do
-        local lane = output.entity.get_transport_line(idx)
-        if lane.can_insert_at_back() then
-          local portLane = Network.getPortLane(output, idx)
-          local buffer = portLane.buffer
-          if buffer[1] and buffer[1].arriveTick <= game.tick then
-            lane.insert_at_back(buffer[1].inventory[1])
-            Network.removeItem(output, portLane, 1)
+        if output.entity and output.entity.valid then
+          local lane = output.entity.get_transport_line(idx)
+          if lane.can_insert_at_back() then
+            local portLane = Network.getPortLane(output, idx)
+            local buffer = portLane.buffer
+            if buffer[1] and buffer[1].arriveTick <= game.tick then
+              lane.insert_at_back(buffer[1].inventory[1])
+              Network.removeItem(output, portLane, 1)
+            end
           end
         end
       end
@@ -185,8 +189,8 @@ function Network.getPort(entity)
     return {
       entity=entity,
       itemCounts={},
-      leftLane={item=tags[MOD_DATA_LEFT_LANE]},
-      rightLane={item=tags[MOD_DATA_RIGHT_LANE]},
+      leftLane={},
+      rightLane={},
     }
   end
   return Network.getPortGroup(entity)[entity.unit_number]
@@ -315,20 +319,35 @@ function Network.addPort(entity, priorEntity)
   local port = priorGroup and priorGroup[priorEntity.unit_number]
   if upgradeInPlace and isSameDirection and port then
     -- For in-place upgrade, preserve the prior port's settings and buffers but replace the port entity
+    local combinator = entity.surface.create_entity{
+      name = COMBINATOR_TYPE,
+      position = entity.position,
+      force = entity.force,
+      create_build_effect_smoke = false,
+      raise_built = false
+    }
     port.entity = entity
+    port.combinator = combinator
     priorGroup[priorEntity.unit_number] = nil
+    AnimationTracker.teardown(priorEntity)
   else
+    local combinator = entity.surface.find_entity(COMBINATOR_TYPE, entity.position) or entity.surface.create_entity{
+      name = COMBINATOR_TYPE,
+      position = entity.position,
+      force = entity.force,
+      create_build_effect_smoke = false,
+      raise_built = false
+    }
     -- For new ports, create an empty model
     port = {
       entity = entity,
+      combinator = combinator,
       itemCounts = {},
       leftLane = {
-        item = nil,
         buffer = {},
         bufferLength = MIN_BUFFER_LENGTH,
       },
       rightLane = {
-        item = nil,
         buffer = {},
         bufferLength = MIN_BUFFER_LENGTH,
       },
@@ -345,22 +364,94 @@ function Network.addPort(entity, priorEntity)
   end
   AnimationTracker.setup(entity)
 
-  log("Added: "..entity.name..", "..entity.surface.name)
+  log("Added port: " .. entity.name .. " with unit_number " .. entity.unit_number .. " on surface " .. entity.surface.name)
+end
+
+-- Helper function to set combinator signals based on item settings
+---@param port table
+---@param settings {left=table, right=table}
+function Network.setSettings(port, settings)
+  if not port.combinator or not port.combinator.valid then return end
+  local control = port.combinator.get_or_create_control_behavior()
+  if control then
+    local section1 = control.get_section(1) or control.add_section()
+    local section2 = control.get_section(2) or control.add_section()
+    if settings[MOD_DATA_LEFT_LANE] and settings[MOD_DATA_LEFT_LANE].name then
+      section1.set_slot(1, {
+        value = {
+          type = "item",
+          name = settings[MOD_DATA_LEFT_LANE].name,
+          quality = settings[MOD_DATA_LEFT_LANE].quality or "normal"
+        },
+        min = 1
+      })
+    else
+      section1.clear_slot(1)
+    end
+    if settings[MOD_DATA_RIGHT_LANE] and settings[MOD_DATA_RIGHT_LANE].name then
+      section2.set_slot(1, {
+        value = {
+          type = "item",
+          name = settings[MOD_DATA_RIGHT_LANE].name,
+          quality = settings[MOD_DATA_RIGHT_LANE].quality or "normal"
+        },
+        min = 1
+      })
+    else
+      section2.clear_slot(1)
+    end
+  end
+end
+
+function Network.getSettings(port)
+  if Util.isGhost(port.entity) then
+    return port.entity.tags or {}
+  end
+
+  if not port.combinator or not port.combinator.valid then return end
+  local control = port.combinator.get_or_create_control_behavior()
+  if not control then return end
+  local section1 = control.get_section(1)
+  local section2 = control.get_section(2)
+  local leftSlot = section1 and section1.get_slot(1)
+  local rightSlot = section2 and section2.get_slot(1)
+  return {
+    [MOD_DATA_LEFT_LANE] = leftSlot and leftSlot.value,
+    [MOD_DATA_RIGHT_LANE] = rightSlot and rightSlot.value
+  }
+end
+
+function Network.tryGetCombinatorSettings(entity)
+  if not entity or not entity.valid then return end
+  if entity.ghost_name ~= COMBINATOR_TYPE then return end
+  local control = entity.get_or_create_control_behavior()
+  if not control then return end
+  local section = control.get_section(1)
+  if not section then return end
+  local leftSlot = section.get_slot(1)
+  local rightSlot = section.get_slot(2)
+  return {
+    [MOD_DATA_LEFT_LANE] = leftSlot and leftSlot.value,
+    [MOD_DATA_RIGHT_LANE] = rightSlot and rightSlot.value
+  }
 end
 
 function Network.configurePort(entity, leftLane, rightLane)
   if not entity or not entity.valid then return end
+  entity.tags = createSettings(leftLane, rightLane)
 
-  if Util.isGhost(entity) then
-    entity.tags = createSettings(leftLane, rightLane)
-  else
-  local network = Network.get(entity.surface.name)
-  local port = Network.getPort(entity)
+  if not Util.isGhost(entity) then
+    local network = Network.get(entity.surface.name)
+    local port = Network.getPort(entity)
+    port.tags = createSettings(leftLane, rightLane)
 
-  Network.updateDemands(network, port, 1, leftLane)
-  Network.updateDemands(network, port, 2, rightLane)
-  port.leftLane.item = leftLane
-  port.rightLane.item = rightLane
+    Network.updateDemands(network, port, 1, leftLane)
+    Network.updateDemands(network, port, 2, rightLane)
+    
+    -- Update combinator signals
+    if port.combinator and port.combinator.valid then
+      Network.setSettings(port, { [MOD_DATA_LEFT_LANE] = leftLane, [MOD_DATA_RIGHT_LANE] = rightLane })
+    end
   end
 end
 
@@ -374,6 +465,12 @@ function Network.removePort(entity, spillInventory)
 
   Network.updateDemands(network, port, 1, nil)
   Network.updateDemands(network, port, 2, nil)
+  
+  -- Destroy combinator when removing port
+  if port.combinator and port.combinator.valid then
+    port.combinator.destroy()
+  end
+  
   portGroup[entity.unit_number] = nil
 
   function spill(lane)
@@ -398,16 +495,6 @@ function Network.removePort(entity, spillInventory)
   log("Removed: "..entity.name..", "..entity.surface.name)
 end
 
--- Returns configuration settings for the given entity in a tags-compatible table
-function Network.exportSettings(entity)
-  if Util.isGhost(entity) then
-    return entity.tags or {}
-  else
-    local port = Network.getPort(entity)
-    return createSettings(port.leftLane.item, port.rightLane.item)
-  end
-end
-
 function createSettings(leftItem, rightItem)
   return {
     [MOD_DATA_LEFT_LANE] = leftItem,
@@ -420,7 +507,10 @@ function Network.importSettings(entity, tags)
   if Util.isGhost(entity) then
     entity.tags = tags
   else
-  Network.configurePort(entity, tags[MOD_DATA_LEFT_LANE], tags[MOD_DATA_RIGHT_LANE])
+    local leftItem = tags[MOD_DATA_LEFT_LANE]
+    local rightItem = tags[MOD_DATA_RIGHT_LANE]
+    
+    Network.configurePort(entity, leftItem, rightItem)
   end
 end
 

--- a/scripts/network.lua
+++ b/scripts/network.lua
@@ -32,14 +32,26 @@ local MIN_BUFFER_LENGTH = 6 * 4 -- 6 tiles
 local BUFFER_LENGTH_RECALC_TICKS = 30 * 60 -- 30 seconds in ticks
 local INSERTER_SCAN_RADIUS = 3
 
+-- Helper functions for lane operations
+function Network.forEachLane(port, callback)
+  callback(port.leftLane, 1)
+  callback(port.rightLane, 2)
+end
+
+function Network.getPortLane(port, lane)
+  if lane == 1 then return port.leftLane
+  elseif lane == 2 then return port.rightLane end
+  return nil
+end
+
 function Network.init()
   if not storage.networks then
     storage.networks = {}
   end
 end
 
-function trackInput(network, supplies, port, item, laneIndex, inserter)
-  -- We have an iteam ready, now check if any outputs want it
+local function trackInput(network, supplies, port, item, laneIndex, inserter)
+  -- We have an item ready, now check if any outputs want it
   local itemKey = Util.itemFilterToKey(item)
   local demands = network.demands[itemKey]
   if not demands or #demands == 0 then return end
@@ -53,6 +65,132 @@ function trackInput(network, supplies, port, item, laneIndex, inserter)
   table.insert(inputs, { port=port, lane=laneIndex, inserter=inserter })
 end
 
+-- Collect all inputs with items ready to deliver
+local function collectSupplies(network, surface)
+  local supplies = {}
+  
+  for _, inPort in pairs(network.inputs) do
+    local entity = inPort.entity
+    if not entity or not entity.valid then goto nextPort end
+    
+    -- Check for items ready on each input port lane
+    local canDrop = false
+    for idx = 1, 2 do
+      local lane = entity.get_transport_line(idx)
+      
+      -- If there's room to insert an item at the end of the lane, it's not full yet
+      if lane.can_insert_at(lane.line_length - 0.25) then
+        canDrop = true
+        goto nextLane
+      end
+      
+      -- [1] should be the last item on the lane
+      trackInput(network, supplies, inPort, lane[1], idx)
+      ::nextLane::
+    end
+    
+    if canDrop then
+      -- Check if there's an inserter waiting to drop here as well
+      local inserters = surface.find_entities_filtered{
+        position = entity.position, 
+        radius = INSERTER_SCAN_RADIUS, 
+        type = "inserter"
+      }
+      
+      for _, inserter in pairs(inserters) do
+        if inserter.drop_target == entity
+          and inserter.held_stack.count > 0
+          and Util.positionsEqual(inserter.held_stack_position, inserter.drop_position) then
+          trackInput(network, supplies, inPort, inserter.held_stack, nil, inserter)
+        end
+      end
+    end
+    
+    ::nextPort::
+  end
+  
+  return supplies
+end
+
+-- Distribute items from inputs to outputs
+local function distributeItems(network, supplies, recalcBufferLenghts)
+  if recalcBufferLenghts then
+    -- Reset the buffer lengths for each output so they'll update to the farthest recent input
+    for _, outPort in pairs(network.outputs) do
+      outPort.bufferLength = MIN_BUFFER_LENGTH
+    end
+  end
+
+  -- Deliver each input item to the next output buffer in the round-robin list
+  for itemKey, inputs in pairs(supplies) do
+    local demands = network.demands[itemKey]
+    
+    Util.tableShuffle(inputs)
+    local lastSupplyIdx, inputEntry = next(inputs, nil)
+    if not lastSupplyIdx then goto nextItem end
+
+    for _ = 1, #demands do
+      if not demands[demands.lastIndex] then
+        demands.lastIndex = 1
+      end
+      
+      local outputEntry = demands[demands.lastIndex]
+      if outputEntry and outputEntry.port then
+        local manhattanDistance = Util.manhattanDistance(
+          inputEntry.port.entity.position, 
+          outputEntry.port.entity.position
+        )
+
+        -- Advance to the next output
+        demands.lastIndex = demands.lastIndex + 1
+
+        -- Don't proceed unless there's room in this output buffer
+        local output = Network.getPortLane(outputEntry.port, outputEntry.lane)
+        output.bufferLength = math.max(output.bufferLength, manhattanDistance * 4) -- 4 items/square 
+
+        if #output.buffer < output.bufferLength then
+          if inputEntry.lane then
+            -- Insert from one of the input's lanes
+            local inputLane = inputEntry.port.entity.get_transport_line(inputEntry.lane)
+            Network.insertItem(outputEntry.port, output, inputLane[1], manhattanDistance)
+          else
+            -- Insert from an inserter ready to drop on the input
+            local inserter = inputEntry.inserter
+            Network.insertItem(outputEntry.port, output, inserter.held_stack, manhattanDistance)
+          end
+
+          -- Advance to the next input
+          lastSupplyIdx, inputEntry = next(inputs, lastSupplyIdx)
+          if not lastSupplyIdx then goto nextItem end -- No more available
+        end
+      end
+    end
+    
+    ::nextItem::
+  end
+end
+
+-- Process output buffers and push items onto output belts
+local function processOutputBuffers(network)
+  for _, output in pairs(network.outputs) do
+    if not output.entity or not output.entity.valid then goto nextOutput end
+    
+    for idx = 1, 2 do
+      local lane = output.entity.get_transport_line(idx)
+      if lane.can_insert_at_back() then
+        local portLane = Network.getPortLane(output, idx)
+        local buffer = portLane.buffer
+        if buffer[1] and buffer[1].arriveTick <= game.tick then
+          lane.insert_at_back(buffer[1].inventory[1])
+          Network.removeItem(output, portLane, 1)
+        end
+      end
+    end
+    
+    ::nextOutput::
+  end
+end
+
 function Network.tick()
   local recalcBufferLenghts = not storage.nextRecalcTick or game.tick >= storage.nextRecalcTick
   if recalcBufferLenghts then
@@ -61,110 +199,15 @@ function Network.tick()
 
   for _, surface in pairs(game.surfaces) do
     local network = Network.get(surface.name)
-    local supplies = {
-      -- [itemFilterKey] = { {port=port1, lane=1}, {port=port1, lane=2} }
-    }
-
-    -- Collect all inputs with items ready to deliver
-    for _, inPort in pairs(network.inputs) do
-      local entity = inPort.entity
-
-      -- Check for items ready on each input port lane
-      local canDrop = false
-      for idx = 1, 2 do
-        if not entity or not entity.valid then
-          goto laneLoop
-        end
-        local lane = entity.get_transport_line(idx)
-        
-        -- If there's room to insert an item at the end of the lane, it's not full yet
-        if lane.can_insert_at(lane.line_length - 0.25) then
-          canDrop = true
-          goto laneLoop
-        end
-        
-        -- [1] should be the last item on the lane
-        trackInput(network, supplies, inPort, lane[1], idx)
-        ::laneLoop::
-      end
-      if canDrop then
-        -- Check if there's an inserter waiting to drop here as well
-        local inserters = surface.find_entities_filtered{position=entity.position, radius=INSERTER_SCAN_RADIUS, type="inserter"}
-        for _, inserter in pairs(inserters) do
-          if inserter.drop_target == entity
-            and inserter.held_stack.count > 0
-            and Util.positionsEqual(inserter.held_stack_position, inserter.drop_position) then
-            trackInput(network, supplies, inPort, inserter.held_stack, nil, inserter)
-          end
-        end
-      end
-    end
-
-    if recalcBufferLenghts then
-      -- Reset the buffer lengths for each output so they'll update to the farthest recent input
-      for _, outPort in pairs(network.outputs) do
-        outPort.bufferLength = MIN_BUFFER_LENGTH
-      end
-    end
-
-    -- Deliver each input item to the next output buffer in the round-robin list
-    for itemKey, inputs in pairs(supplies) do
-      local demands = network.demands[itemKey]
-
-      Util.tableShuffle(inputs)
-      local lastSupplyIdx, inputEntry = next(inputs, nil)
-      if not lastSupplyIdx then break end
-
-      for _ = 1, #demands do
-        if not demands[demands.lastIndex] then
-          demands.lastIndex = 1
-        end
-        local outputEntry = demands[demands.lastIndex]
-        if outputEntry and outputEntry.port then
-          local manhattanDistance = Util.manhattanDistance(inputEntry.port.entity.position, outputEntry.port.entity.position)
-
-          -- Advance to the next output
-          demands.lastIndex = demands.lastIndex + 1
-
-          -- Don't proceed unless there's room in this output buffer
-          local output = Network.getPortLane(outputEntry.port, outputEntry.lane)
-          output.bufferLength = math.max(output.bufferLength, manhattanDistance * 4) -- 4 items/square 
-
-          if #output.buffer < output.bufferLength then
-            if inputEntry.lane then
-              -- Insert from one of the input's lanes
-              local inputLane = inputEntry.port.entity.get_transport_line(inputEntry.lane)
-              Network.insertItem(outputEntry.port, output, inputLane[1], manhattanDistance)
-            else
-              -- Insert from an inserter ready to drop on the input
-              local inserter = inputEntry.inserter
-              Network.insertItem(outputEntry.port, output, inserter.held_stack, manhattanDistance)
-            end
-
-            -- Advance to the next input
-            lastSupplyIdx, inputEntry = next(inputs, lastSupplyIdx)
-            if not lastSupplyIdx then break end -- No more available
-          end
-        end
-      end
-    end
-
-    -- Push items into outputs from their buffers
-    for _, output in pairs(network.outputs) do
-      for idx = 1, 2 do
-        if output.entity and output.entity.valid then
-          local lane = output.entity.get_transport_line(idx)
-          if lane.can_insert_at_back() then
-            local portLane = Network.getPortLane(output, idx)
-            local buffer = portLane.buffer
-            if buffer[1] and buffer[1].arriveTick <= game.tick then
-              lane.insert_at_back(buffer[1].inventory[1])
-              Network.removeItem(output, portLane, 1)
-            end
-          end
-        end
-      end
-    end
+    
+    -- Step 1: Collect supplies from inputs
+    local supplies = collectSupplies(network, surface)
+    
+    -- Step 2: Distribute items to outputs
+    distributeItems(network, supplies, recalcBufferLenghts)
+    
+    -- Step 3: Process output buffers
+    processOutputBuffers(network)
   end
 end
 
@@ -185,21 +228,31 @@ end
 function Network.getPort(entity)
   if not Util.isPort(entity) then return nil end
   if Util.isGhost(entity) then
-    local tags = entity.tags or {}
     return {
-      entity=entity,
-      itemCounts={},
-      leftLane={},
-      rightLane={},
+      entity = entity,
+      itemCounts = {},
+      leftLane = {},
+      rightLane = {},
     }
   end
   return Network.getPortGroup(entity)[entity.unit_number]
 end
 
-function Network.getPortLane(port, lane)
-  if lane == 1 then return port.leftLane
-  elseif lane == 2 then return port.rightLane end
-  return nil
+-- Creates a new port data structure
+function Network.createPort(entity, combinator)
+  return {
+    entity = entity,
+    combinator = combinator,
+    itemCounts = {},
+    leftLane = {
+      buffer = {},
+      bufferLength = MIN_BUFFER_LENGTH,
+    },
+    rightLane = {
+      buffer = {},
+      bufferLength = MIN_BUFFER_LENGTH,
+    },
+  }
 end
 
 -- Inserts an item into the given port and lane's buffer and updates the stack's count
@@ -212,7 +265,7 @@ function Network.insertItem(port, lane, itemStack, manhattanDistance)
   local outputSpeed = prototypes.entity[port.entity.name].belt_speed
 
   local entry = {
-    inventory=InventoryPool.checkout(),
+    inventory = InventoryPool.checkout(),
     arriveTick = game.tick + manhattanDistance / outputSpeed,
   }
   entry.inventory.insert(itemStack)
@@ -247,7 +300,7 @@ function updateItemCount(port, itemKey, itemCount)
   if not port.itemCounts then
     -- First time accessed we have to count everything in the buffer
     port.itemCounts = {}
-    function count(lane)
+    local function countLane(lane)
       for _, entry in ipairs(lane.buffer) do
         local item = entry.inventory[1]
         local key = Util.itemFilterToKey(item)
@@ -257,17 +310,19 @@ function updateItemCount(port, itemKey, itemCount)
         port.itemCounts[key] = port.itemCounts[key] + item.count
       end
     end
-    count(port.leftLane)
-    count(port.rightLane)
+    countLane(port.leftLane)
+    countLane(port.rightLane)
   else
     -- After that we can just increment the existing counts
-    if not port.itemCounts[itemKey] then
-      port.itemCounts[itemKey] = 0
-    end
-    port.itemCounts[itemKey] = port.itemCounts[itemKey] + itemCount
+    if itemKey then
+      if not port.itemCounts[itemKey] then
+        port.itemCounts[itemKey] = 0
+      end
+      port.itemCounts[itemKey] = port.itemCounts[itemKey] + itemCount
 
-    if port.itemCounts[itemKey] < 1 then
-      port.itemCounts[itemKey] = nil
+      if port.itemCounts[itemKey] < 1 then
+        port.itemCounts[itemKey] = nil
+      end
     end
   end
 end
@@ -277,32 +332,74 @@ function Network.getDemands(network, itemFilter)
   return network.demands[demandKey]
 end
 
+function Network.trackDemand(network, itemKey, port, lane)
+  if not network.demands[itemKey] then
+    network.demands[itemKey] = { lastIndex = 0 }
+  end
+  table.insert(network.demands[itemKey], { port = port, lane = lane })
+end
+
+function Network.removeDemand(network, itemKey, port, lane)
+  local demands = network.demands[itemKey]
+  if demands then
+    Util.tableRemove(demands, function(entry)
+      return entry.port == port and entry.lane == lane
+    end)
+    if #demands == 0 then
+      network.demands[itemKey] = nil
+    end
+  end
+end
+
 function Network.updateDemands(network, port, laneIndex, newItemFilter)
   local oldItemFilter = Network.getPortLane(port, laneIndex).item
   if Util.itemFiltersEqual(oldItemFilter, newItemFilter) then return end
+  
   if oldItemFilter then
     -- Remove the old demand
     local oldDemandKey = Util.itemFilterToKey(oldItemFilter)
-    local oldItemDemands = network.demands[oldDemandKey]
-    if oldItemDemands then
-      Util.tableRemove(oldItemDemands, function (entry)
-        return entry.port == port and entry.lane == laneIndex
-      end)
-      if #oldItemDemands == 0 then
-        -- Clean up the demand array if now empty
-        network.demands[oldDemandKey] = nil
-      end
-    end
+    Network.removeDemand(network, oldDemandKey, port, laneIndex)
   end
+  
   if newItemFilter then
     -- Add the new demand
     local newDemandKey = Util.itemFilterToKey(newItemFilter)
-    local mewItemDemands = network.demands[newDemandKey]
-    if not mewItemDemands then
-      mewItemDemands = { lastIndex=0 } -- Track the last output index for round-robin delivery
-      network.demands[newDemandKey] = mewItemDemands
+    Network.trackDemand(network, newDemandKey, port, laneIndex)
+  end
+end
+
+-- Gets or creates a combinator for the port
+local function getOrCreateCombinator(entity)
+  return entity.surface.find_entity(COMBINATOR_TYPE, entity.position) or 
+         entity.surface.create_entity{
+           name = COMBINATOR_TYPE,
+           position = entity.position,
+           force = entity.force,
+           create_build_effect_smoke = false,
+           raise_built = false
+         }
+end
+
+-- Handle port upgrade scenarios
+local function handlePortUpgrade(entity, priorEntity, combinator)
+  local isSameDirection = priorEntity and Util.isInput(entity) == Util.isInput(priorEntity)
+  local priorGroup = priorEntity and Network.getPortGroup(priorEntity)
+  local port = priorGroup and priorGroup[priorEntity.unit_number]
+  
+  if priorEntity and isSameDirection and port then
+    -- For in-place upgrade, preserve the prior port's settings and buffers
+    port.entity = entity
+    port.combinator = combinator
+    priorGroup[priorEntity.unit_number] = nil
+    AnimationTracker.teardown(priorEntity)
+    return port
+  else
+    -- Create a new port
+    if priorEntity then
+      -- Remove the old port if upgrading with a different direction
+      Network.removePort(priorEntity)
     end
-    table.insert(mewItemDemands, { port=port, lane=laneIndex })
+    return Network.createPort(entity, combinator)
   end
 end
 
@@ -313,63 +410,23 @@ function Network.addPort(entity, priorEntity)
   if Util.isGhost(entity) then return end
 
   local priorIsGhost = priorEntity and Util.isGhost(priorEntity)
-  local upgradeInPlace = not not priorEntity
-  local isSameDirection = upgradeInPlace and Util.isInput(entity) == Util.isInput(priorEntity)
-  local priorGroup = priorEntity and Network.getPortGroup(priorEntity)
-  local port = priorGroup and priorGroup[priorEntity.unit_number]
-  if upgradeInPlace and isSameDirection and port then
-    -- For in-place upgrade, preserve the prior port's settings and buffers but replace the port entity
-    local combinator = entity.surface.create_entity{
-      name = COMBINATOR_TYPE,
-      position = entity.position,
-      force = entity.force,
-      create_build_effect_smoke = false,
-      raise_built = false
-    }
-    port.entity = entity
-    port.combinator = combinator
-    priorGroup[priorEntity.unit_number] = nil
-    AnimationTracker.teardown(priorEntity)
-  else
-    local combinator = entity.surface.find_entity(COMBINATOR_TYPE, entity.position) or entity.surface.create_entity{
-      name = COMBINATOR_TYPE,
-      position = entity.position,
-      force = entity.force,
-      create_build_effect_smoke = false,
-      raise_built = false
-    }
-    -- For new ports, create an empty model
-    port = {
-      entity = entity,
-      combinator = combinator,
-      itemCounts = {},
-      leftLane = {
-        buffer = {},
-        bufferLength = MIN_BUFFER_LENGTH,
-      },
-      rightLane = {
-        buffer = {},
-        bufferLength = MIN_BUFFER_LENGTH,
-      },
-    }
-    if upgradeInPlace then
-      -- If the new port direction doesn't match the prior one, remove the old port
-      Network.removePort(priorEntity)
-    end
-  end
-  Network.getPortGroup(entity)[entity.unit_number] = port
+  local network = Network.get(entity.surface.name)
+  local portGroup = Network.getPortGroup(entity)
+  local combinator = getOrCreateCombinator(entity)
+  
+  -- Handle upgrades or new ports
+  local port = handlePortUpgrade(entity, priorEntity, combinator)
+  portGroup[entity.unit_number] = port
 
   if priorIsGhost and priorEntity.tags then
     Network.importSettings(entity, priorEntity.tags)
   end
+  
   AnimationTracker.setup(entity)
-
   log("Added port: " .. entity.name .. " with unit_number " .. entity.unit_number .. " on surface " .. entity.surface.name)
 end
 
 -- Helper function to set combinator signals based on item settings
----@param port table
----@param settings {left=table, right=table}
 function Network.setSettings(port, settings)
   if not port.combinator or not port.combinator.valid then return end
   local control = port.combinator.get_or_create_control_behavior()
@@ -426,10 +483,11 @@ function Network.tryGetCombinatorSettings(entity)
   if entity.ghost_name ~= COMBINATOR_TYPE then return end
   local control = entity.get_or_create_control_behavior()
   if not control then return end
-  local section = control.get_section(1)
-  if not section then return end
-  local leftSlot = section.get_slot(1)
-  local rightSlot = section.get_slot(2)
+  local section1 = control.get_section(1)
+  local section2 = control.get_section(2)
+  if not section1 or not section2 then return end
+  local leftSlot = section1.get_slot(1)
+  local rightSlot = section2.get_slot(1)
   return {
     [MOD_DATA_LEFT_LANE] = leftSlot and leftSlot.value,
     [MOD_DATA_RIGHT_LANE] = rightSlot and rightSlot.value
@@ -438,20 +496,39 @@ end
 
 function Network.configurePort(entity, leftLane, rightLane)
   if not entity or not entity.valid then return end
-  entity.tags = createSettings(leftLane, rightLane)
+  local settings = createSettings(leftLane, rightLane)
+  entity.tags = settings
 
   if not Util.isGhost(entity) then
     local network = Network.get(entity.surface.name)
     local port = Network.getPort(entity)
-    port.tags = createSettings(leftLane, rightLane)
+    port.tags = settings
 
     Network.updateDemands(network, port, 1, leftLane)
     Network.updateDemands(network, port, 2, rightLane)
     
     -- Update combinator signals
     if port.combinator and port.combinator.valid then
-      Network.setSettings(port, { [MOD_DATA_LEFT_LANE] = leftLane, [MOD_DATA_RIGHT_LANE] = rightLane })
+      Network.setSettings(port, settings)
     end
+  end
+end
+
+-- Spill lane items onto the ground or to the provided inventory
+local function spillLaneItems(entity, lane, spillInventory)
+  for _, slot in pairs(lane.buffer) do
+    if spillInventory then
+      -- Insert into the given inventory
+      spillInventory.insert(slot.inventory[1])
+    else
+      -- Otherwise, spill onto the ground around the port
+      entity.surface.spill_item_stack{
+        position = entity.position,
+        stack = slot.inventory[1],
+        allow_belts = false,
+      }
+    end
+    InventoryPool.checkin(slot.inventory)
   end
 end
 
@@ -462,6 +539,7 @@ function Network.removePort(entity, spillInventory)
   local network = Network.get(entity.surface.name)
   local portGroup = Network.getPortGroup(entity)
   local port = portGroup[entity.unit_number]
+  if not port then return end
 
   Network.updateDemands(network, port, 1, nil)
   Network.updateDemands(network, port, 2, nil)
@@ -473,24 +551,9 @@ function Network.removePort(entity, spillInventory)
   
   portGroup[entity.unit_number] = nil
 
-  function spill(lane)
-    for _, slot in pairs(lane.buffer) do
-      if spillInventory then
-        -- Insert into the given inventory
-        spillInventory.insert(slot.inventory[1])
-      else
-        -- Otherwise, spill onto the ground around the port
-        entity.surface.spill_item_stack{
-          position=entity.position,
-          stack=slot.inventory[1],
-          allow_belts=false,
-        }
-      end
-      InventoryPool.checkin(slot.inventory)
-    end
-  end
-  spill(port.leftLane)
-  spill(port.rightLane)
+  spillLaneItems(entity, port.leftLane, spillInventory)
+  spillLaneItems(entity, port.rightLane, spillInventory)
+  
   AnimationTracker.teardown(entity)
   log("Removed: "..entity.name..", "..entity.surface.name)
 end


### PR DESCRIPTION
This is a big change, it does the following:

- Allows for blueprint parameterization
- Allows alt-mode visibility of filters
- Fixes robot upgrades (which previously would dump items on the floor)

It does this by changing the backend storage to a clone of Constant Combinator, which is visible by the blueprints system.


**Testing**
My code here is admittedly a bit messy, but I've tested many different cases, will start running this version (along with the migration I added) in a large-ish base of mine tonight.